### PR TITLE
update azure-functions-java-library 1.2.0 -> 1.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,6 @@ lazy val azure = (project in file("azure"))
   .settings(
     name := "my-awesome-function-azure",
     libraryDependencies ++= azureDependencies,
-    resolvers ++= azureResolvers,
     assemblyOutputPath in assembly := baseDirectory.value / "app" / "MyAwesomeFunction.jar",
   )
   .dependsOn(root)
@@ -41,11 +40,7 @@ lazy val azure = (project in file("azure"))
 // Todo: AWS Lambda
 
 val azureDependencies = Seq(
-  "com.microsoft.azure.functions" % "azure-functions-java-library" % "1.2.0"
-)
-
-val azureResolvers = Seq(
-  "Central Maven Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+  "com.microsoft.azure.functions" % "azure-functions-java-library" % "1.2.2"
 )
 
 scalafmtOnCompile in ThisBuild := true


### PR DESCRIPTION
ref: https://github.com/Azure/azure-functions-java-library/releases/tag/1.2.2

java-8-parentのSNAPSHOTではなく正式バージョンを使うようになったので、Resolverが不要になったので削除
