### PR TITLE
Azure Functionsの環境をDockerに落とし込んで、ローカルにAzure Functions Core Toolsを入れなくて済むようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ azure/functions.zip: azure/app/MyAwesomeFunction.jar
 
 docker/init:
 	docker build . -f java.Dockerfile -t azure-functions-java-host
+
+docker/azure-functions:
+	docker-compose run --service-ports azure-functions

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,6 @@ deploy/azure: azure/functions.zip
 
 azure/functions.zip: azure/app/MyAwesomeFunction.jar
 	cd azure && zip -r9 functions.zip app
+
+docker/init:
+	docker build . -f java.Dockerfile -t azure-functions-java-host

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@
 ```sh
 $ sbt azure/assembly
 # if you want to handle file changes and build
-$ sbt "~azure/assembly"
+$ sbt "project azure" "~assembly"
+```
+
+or use Makefile
+```sh
+$ make azure/build
+# if you want to handle file changes and build
+$ make azure/build-watch
 ```
 
 ## How to run
@@ -21,4 +28,10 @@ $ cd azure/app
 $ func host start
 # if you want to debug jar by attaching process
 $ func host start --language-worker -- "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+```
+
+if you can use Docker, use Docker! (recommended)
+```sh
+$ make docker/init # build Azure Functions Java Host
+$ make docker/azure-functions
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services: 
+  azure-functions:
+    image: azure-functions-java-host # 将来的に azure-functions/java:2.0 になるはず
+    ports: 
+      - "8080:80"
+    volumes: 
+      - ./azure/app:/home/site/wwwroot
+
+  azure-functions-debug:
+    image: azure-functions-java-host
+    ports: 
+      - "8080:80"
+      - "5005:5005"
+    environment: 
+      - languageWorkers:java:arguments="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+    volumes: 
+      - ./azure/app:/home/site/wwwroot

--- a/java.Dockerfile
+++ b/java.Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=mcr.microsoft.com/azure-functions/base:2.0-alpine
+FROM ${BASE_IMAGE} as runtime-image
+
+FROM openjdk:8-jdk-alpine as jdk
+RUN mkdir -p /usr/lib/jvm/java-1.8-openjdk
+
+FROM microsoft/dotnet:2.2-aspnetcore-runtime-alpine
+
+RUN apk add --no-cache libc6-compat libnsl && \
+    # workaround for https://github.com/grpc/grpc/issues/17255
+    ln -s /usr/lib/libnsl.so.2 /usr/lib/libnsl.so.1
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=java
+
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+COPY --from=runtime-image [ "/workers/java", "/azure-functions-host/workers/java" ]
+
+COPY --from=jdk /usr/lib/jvm/java-1.8-openjdk /usr/lib/jvm/java-1.8-openjdk
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
+
+CMD [ "dotnet", "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll" ] 


### PR DESCRIPTION
各環境でazure-functions-core-tools入れるの面倒だなーって思ったので、とりあえずDocker化した。
sbtとかその辺も固めてbuild出来るといいんだろうけど、とりあえずはこんなもんで。