### PR TITLE
jsonのSerialize/Deserializeに使うライブラリを変える

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,4 +43,12 @@ val azureDependencies = Seq(
   "com.microsoft.azure.functions" % "azure-functions-java-library" % "1.2.2"
 )
 
+val circeVersion = "0.11.1"
+
+val commonDependencies = Seq() ++ Seq(
+  "io.circe" %% "circe-core",
+  "io.circe" %% "circe-generic",
+  "io.circe" %% "circe-parser"
+).map(_ % circeVersion)
+
 scalafmtOnCompile in ThisBuild := true


### PR DESCRIPTION
`io.circe` の方が簡単な型を使う分には現時点で使いやすい感じがした

あとヘルパークラス作ったときにリフレクションで解決してて詰まった